### PR TITLE
Adding readme badges for build status and npm links.

### DIFF
--- a/.github/workflows/typescript-build.yml
+++ b/.github/workflows/typescript-build.yml
@@ -1,12 +1,16 @@
-name: CI
+name: TypeScript Build
 
 on:
   push:
     branches:
       - main
+    paths: 
+      - 'sdk/js/packages/**'
   pull_request:
     branches:
       - main
+    paths: 
+      - 'sdk/js/packages/**'
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Microsoft AI Chat Protocol SDK
 
+[![NPM Package](https://img.shields.io/npm/v/@microsoft/ai-chat-protocol)](https://www.npmjs.com/package/@microsoft/ai-chat-protocol)
+[![TypeScript Build](https://github.com/microsoft/ai-chat-protocol/actions/workflows/typescript-build.yml/badge.svg)](https://github.com/microsoft/ai-chat-protocol/actions/workflows/typescript-build.yml)
+
 The Microsoft AI Chat Protocol SDK is a library for easily building AI Chat interfaces.
 
 *Note: we are currently in public preview. Your feedback is greatly appreciated as we get ready to be generally available!*


### PR DESCRIPTION
This pull request includes changes to improve the visibility of the TypeScript build status and to focus the build process on the relevant paths. The most important changes include renaming the GitHub action and specifying paths for the action to focus on, and adding badges to the `README.md` file to show the NPM package and TypeScript build status.

GitHub Actions:

* [`.github/workflows/typescript-build.yml`](diffhunk://#diff-a814ee9f4ca6f63c3efc75305d869a44b993dcf67bb3da5772eea1271d589bfbL1-R13): The name of the GitHub action has been changed from "CI" to "TypeScript Build". Additionally, the action has been specified to only run on push or pull request events that affect files in the 'sdk/js/packages/**' path. This change helps to focus the build process only on relevant changes.

Documentation:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R3-R5): Two badges have been added to the top of the file. One badge shows the version of the NPM package, and the other shows the status of the TypeScript build. These badges provide a quick and easy way to see the status of the project.