### PR TITLE
Adding release pipeline.

### DIFF
--- a/.github/workflows/typescript-release.yml
+++ b/.github/workflows/typescript-release.yml
@@ -1,0 +1,70 @@
+name: TypeScript Release
+
+on:
+  push:
+    tags:
+      - 'release/js/*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20.11.1'
+
+    - name: Install Dependencies
+      run: npm ci
+      working-directory: ./sdk/js/packages/client
+
+    - name: Run Linter
+      run: npm run lint
+      working-directory: ./sdk/js/packages/client
+
+    - name: Check Format
+      run: npm run check-format
+      working-directory: ./sdk/js/packages/client
+
+    - name: Build
+      run: npm run build
+      working-directory: ./sdk/js/packages/client
+
+    - name: Test
+      run: npm test
+      working-directory: ./sdk/js/packages/client
+
+    - name: Set Version
+      run: |
+          version=${GITHUB_REF#refs/tags/release/js/}
+          npm pkg set version="${version}"
+      working-directory: ./sdk/js/packages/client
+
+    - name: Pack
+      run: npm pack
+      working-directory: ./sdk/js/packages/client
+
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: npm-package
+        path: ./sdk/js/packages/client/*.tgz
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+    - name: Download Artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: npm-package
+        path: ./packages/
+
+    - name: Create Release
+      run:
+        version=${GITHUB_REF#refs/tags/release/js/}
+        gh release create release/js/$version -t "Release $version" ./packages/*.tgz      


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for releasing TypeScript packages. The workflow is triggered when a new tag matching the pattern 'release/js/*' is pushed. The workflow automates several tasks including setting up the environment, installing dependencies, running linter and format checks, building the package, running tests, setting the package version, packing the package, and uploading the package as an artifact. After the build job, a release job is run which downloads the artifact and creates a new GitHub release with the package.

Here's a summary of the most important changes:

* [`.github/workflows/typescript-release.yml`](diffhunk://#diff-0b7fef318c4e5f29303a3c0987cba0fa05258dde16647f346093a430fc8f6cdaR1-R70): A new workflow has been added. This workflow is triggered on a push event when a new tag matching the pattern 'release/js/*' is pushed. The workflow contains two jobs: `build` and `release`. The `build` job checks out the code, sets up Node.js, installs dependencies, runs linter and format checks, builds the package, runs tests, sets the package version, packs the package, and uploads the package as an artifact. The `release` job, which depends on the `build` job, downloads the artifact and creates a new GitHub release with the package.