### PR TITLE
Fixing release pipeline.

### DIFF
--- a/.github/workflows/typescript-release.yml
+++ b/.github/workflows/typescript-release.yml
@@ -65,6 +65,8 @@ jobs:
         path: ./packages/
 
     - name: Create Release
+      env:
+        GH_TOKEN: ${{ github.token}}
       run:
         version=${GITHUB_REF#refs/tags/release/js/}
-        gh release create release/js/$version -t "Release $version" ./packages/*.tgz      
+        gh release create release/js/$version -t "Typescript Release $version" ./packages/*.tgz      


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/typescript-release.yml` file. The change modifies the environment variables and the title of the release in the `Create Release` job.

* [`.github/workflows/typescript-release.yml`](diffhunk://#diff-0b7fef318c4e5f29303a3c0987cba0fa05258dde16647f346093a430fc8f6cdaR68-R72): Added `GH_TOKEN` as an environment variable and updated the release title to "Typescript Release $version" in the `Create Release` job.