### PR TITLE
Update ndjson link in spec

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -90,7 +90,7 @@ Example of the overrides object:
 
 ## HTTP responses from AI Chat App endpoints
 
-The HTTP response should either be JSON for a non-streaming response, or [newline-delimited JSON](https://ndjson.org/home/) ("NDJSON") for a streaming response.
+The HTTP response should either be JSON for a non-streaming response, or [newline-delimited JSON](https://github.com/ndjson/ndjson-spec) ("NDJSON") for a streaming response.
 
 ### Non-streaming response
 


### PR DESCRIPTION
The old one no longer works.

Alternatively, we could link to JSON lines, as there seems to be an effort to consolidate on specs and the NDJSON creator is no longer working on it. See https://github.com/ndjson/ndjson-spec/issues/35#issuecomment-1285673417

If we link to JSON-lines, we may consider using that content-type instead, however.