### PR TITLE
Allowing endpoints that don't end in '/'

### DIFF
--- a/sdk/js/packages/client/src/client.ts
+++ b/sdk/js/packages/client/src/client.ts
@@ -7,7 +7,7 @@ import {
   isKeyCredential,
   KeyCredential,
   RequestParameters,
-  TokenCredential,  
+  TokenCredential,
 } from "@typespec/ts-http-runtime";
 import { getAsyncIterable } from "./util/ndjson.js";
 import { asStream } from "./util/stream.js";
@@ -90,7 +90,7 @@ export class AIChatProtocolClient {
   ) {
     const absoluteEndpoint = toAbsoluteUrl(endpoint);
     const [origin, basePath] = splitURL(absoluteEndpoint);
-    this.basePath = basePath; 
+    this.basePath = basePath;
     const defaults: AIChatClientOptions = {
       allowInsecureConnection: isLocalhost(absoluteEndpoint),
     };
@@ -121,8 +121,10 @@ export class AIChatProtocolClient {
         context: options.context,
         sessionState: options.sessionState,
       },
-    };    
-    const response = await this.client.path(this.basePath).post(request, options);
+    };
+    const response = await this.client
+      .path(this.basePath)
+      .post(request, options);
     const { status, body } = response;
     if (!/2\d\d/.test(status)) {
       handleFailedRequest(status, body);
@@ -150,7 +152,7 @@ export class AIChatProtocolClient {
         context: options.context,
         sessionState: options.sessionState,
       },
-    };    
+    };
     const response = await asStream(
       this.client.path(`${this.basePath}/stream`).post(request, options),
     );


### PR DESCRIPTION
This pull request makes significant changes to the `AIChatProtocolClient` class in the `sdk/js/packages/client/src/client.ts` file. The changes primarily focus on the way URLs are handled within the client. A new function `splitURL` is introduced to parse the URL into origin and path components. The `AIChatProtocolClient` constructor and methods are then updated to use these separate components instead of the absolute URL.

URL Handling Changes:

* [`sdk/js/packages/client/src/client.ts`](diffhunk://#diff-5bc641c60342c03d4933090ee332284b61eb565dea34f42d5c356cd2f20d0f4bR70-R79): Introduced a new function `splitURL` which takes a URL string as input and returns a tuple containing the origin and path.
* [`sdk/js/packages/client/src/client.ts`](diffhunk://#diff-5bc641c60342c03d4933090ee332284b61eb565dea34f42d5c356cd2f20d0f4bR92-R100): Updated the `AIChatProtocolClient` constructor to use the `splitURL` function to parse the endpoint into origin and path. The path is stored in a new `basePath` member variable. The `getClient` function is then called with the origin instead of the absolute endpoint.
* [`sdk/js/packages/client/src/client.ts`](diffhunk://#diff-5bc641c60342c03d4933090ee332284b61eb565dea34f42d5c356cd2f20d0f4bL116-R125): Updated the `post` method call in the `client.path` function to use `this.basePath` instead of the root path ("/").
* [`sdk/js/packages/client/src/client.ts`](diffhunk://#diff-5bc641c60342c03d4933090ee332284b61eb565dea34f42d5c356cd2f20d0f4bL146-R155): Similarly, updated the `post` method call in the `client.path` function within the `asStream` function to use `this.basePath` instead of the root path ("/stream").