### PR TITLE
Update samples README.md

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -9,7 +9,7 @@ If you'd like to run the samples, follow these steps:
 1. Clone the repository to your machine.
 1. In one terminal, navigate to the `frontend/js/react` directory.
 1. In the `frontend/js/react` directory, run `npm install` to install your dependencies, including [`@microsoft/ai-chat-protocol`](https://www.npmjs.com/package/@microsoft/ai-chat-protocol).
-2. 1. Next, run `npm run dev` to start your web application.
+1. Next, run `npm run dev` to start your web application.
 
 ## Backend
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -7,9 +7,9 @@ If you'd like to run the samples, follow these steps:
 ## Frontend
 
 1. Clone the repository to your machine.
-1. In one terminal, navigate to the `frontend` directory.
-1. In the `frontend` directory, run `npm install` to install your dependencies, including [`@microsoft/ai-chat-protocol`](https://www.npmjs.com/package/@microsoft/ai-chat-protocol).
-1. Next, run `npm run dev` to start your web application.
+1. In one terminal, navigate to the `frontend/js/react` directory.
+1. In the `frontend/js/react` directory, run `npm install` to install your dependencies, including [`@microsoft/ai-chat-protocol`](https://www.npmjs.com/package/@microsoft/ai-chat-protocol).
+2. 1. Next, run `npm run dev` to start your web application.
 
 ## Backend
 


### PR DESCRIPTION
This pull request includes a change to the `samples/README.md` file to update the instructions for running the samples. The instructions now direct the user to navigate to the `frontend/js/react` directory instead of the `frontend` directory, and then install dependencies and start the web application from there.fixed frontend path