### PR TITLE
Added Generics to the Contexts in the Typescript SDK models

### DIFF
--- a/sdk/js/packages/client/src/model/model.ts
+++ b/sdk/js/packages/client/src/model/model.ts
@@ -10,33 +10,33 @@ export interface AIChatFile {
   data: Uint8Array | File | Buffer;
 }
 
-export interface AIChatMessage {
+export interface AIChatMessage<TCtx extends object = object> {
   role: AIChatRole;
   content: string;
-  context?: object;
+  context?: TCtx;
   files?: AIChatFile[];
 }
 
-export interface AIChatMessageDelta {
+export interface AIChatMessageDelta<TCtx extends object = object> {
   role?: AIChatRole;
   content?: string;
-  context?: object;
+  context?: TCtx;
 }
 
-export interface AIChatCompletion {
+export interface AIChatCompletion<TCtx extends object = object> {
   message: AIChatMessage;
   sessionState?: unknown;
-  context?: object;
+  context?: TCtx;
 }
 
-export interface AIChatCompletionDelta {
+export interface AIChatCompletionDelta<TCtx extends object = object> {
   delta: AIChatMessageDelta;
   sessionState?: unknown;
-  context?: object;
+  context?: TCtx;
 }
 
-export interface AIChatCompletionOptions {
-  context?: object;
+export interface AIChatCompletionOptions<TCtx extends object = object> {
+  context?: TCtx;
   sessionState?: unknown;
 }
 


### PR DESCRIPTION
Features Added:
* Enables Generics to the Context for all types/interfaces that has a context
* The Generic has type constraint to `object`
* It's a non-breaking change as the generic is optional and defaults to the original `object`

Reason:

I would like to strongly type the AIChatMessage and other context-enabled types; however right now, I would have to redefine the type using type intersection. The more ergonomic approach is to use generics for define what context type should be for these types/interfaces.

Demo:

With the proposed change in this PR, one can set the context type like so:

```ts
type UserMsgContext = {
  messageId: string;
  userId: string;
};

type AssistantMsgContext = {
  messageId: string;
  feedback?: {
    rating: number;
    comments: string;
  };
};

type UserMessage = AIChatMessage<UserMsgContext>;
type AssistantMessage = AIChatMessage<AssistantMsgContext>;
```
and we can have proper typing:
![image](https://github.com/user-attachments/assets/d6addd57-481a-41f1-acd2-f30a50a8d3b8)
![image](https://github.com/user-attachments/assets/c5d90f73-99a8-47bd-a2df-9a0bb36d1c83)

Also, if the dev tries to set the context to a non-object, it will properly have a type-check error:
![image](https://github.com/user-attachments/assets/b738f397-6440-4491-8821-e3d58a92014e)


